### PR TITLE
Improved Smartnode health check. Faster install.sh.

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -69,7 +69,7 @@ function CheckPoSe () {
       POSE_SCORE=$(curl -s "${URL[$URL_ID]}api/protx?command=info&protxhash=${NODE_PROTX}" | jq -r '.state.PoSePenalty')
     fi
     if [[ $POSE_SCORE == "null" ]]; then
-      echo "$(date -u)  Your NODE_PROTX is invalid, please insert your NODE_PROTX hash in line #19 of check.sh script."
+      echo "$(date -u)  Your NODE_PROTX is invalid, please insert your NODE_PROTX hash in line #18 of check.sh script."
     elif (( $(GetNumber $POSE_SCORE) == -1 )); then
       echo "$(date -u)  Could not get PoSe score for the node. It is possible both explorers are down."
     fi

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# URLs for raptoreum explorers. Main and backup one.
+URL=( 'https://explorer.raptoreum.com/' 'https://raptor.mopsus.com/' )
+URL_ID=0
+POSE_SCORE=0
+PREV_SCORE=0
+LOCAL_HEIGHT=0
+# Variables provided by cron job enviroment variable.
+# They should also be added into .bashrc for user use.
+#NODE_PROTX       -> PROTX of the node in question.
+#RAPTOREUM_CLI    -> Path to the raptoreum-cli
+
+# Add your NODE_PROTX here if you forgot or provided wrong hash during node
+# installation.
+#NODE_PROTX=
+
+function GetNumber () {
+  if [[ ${1} =~ '^[+-]?[0-9]+([.][0-9]+)?$' ]]; then
+    echo "${1}"
+  else
+    echo "-1"
+  fi
+}
+
+function ReadValue () {
+  GetNumber "$(cat ${1} 2>/dev/null)"
+}
+
+# Allow read anything from CLI with $@ arguments. Timeout after 300s.
+function ReadCli () {
+  # This should just echo (return) value with standard stdout.
+  $(${RAPTOREUM_CLI} "$@") &
+  PID=$?
+  for i in {0..300}; do
+    sleep 1
+    if ! ps --pid $PID; then
+      # PID ended. Just exit the function.
+      return
+    fi
+  done
+  # raptoreum-cli did not return after 300s. kill the PID and exit with -1.
+  kill -9 $PID
+  echo -1
+}
+
+function CheckPoSe () {
+  # Check if the Node PoSe score is changing.
+  if [[ ! -z ${NODE_PROTX} ]]; then
+    POSE_SCORE=$(GetNumber $(curl -s "${URL[$URL_ID]}api/protx?command=info&protxhash=${NODE_PROTX}" | jq -r '.state.PoSePenalty'))
+    # Check if the response returned a number or failed.
+    if (( POSE_SCORE < 0 )); then
+      URL_ID=$(( (URL_ID + 1) % 2 ))
+      POSE_SCORE=$(GetNumber $(curl -s "${URL[$URL_ID]}api/protx?command=info&protxhash=${NODE_PROTX}" | jq -r '.state.PoSePenalty'))
+    fi
+  else
+    echo "$(date)  Your NODE_PROTX is empty. Please reinitialize the node again or add it in line #15 of check.sh script."
+  fi
+  if (( $POSE_SCORE == -1 )); then
+    echo "$(date)  Could not get PoSe score for the node. It is possible both explorers are down."
+    echo "$(date)  If it happens a lot, please insert your protx hash in line #15 of check.sh script."
+  fi
+  PREV_SCORE=$(ReadValue "/tmp/pose_score")
+  echo ${POSE_SCORE} >/tmp/pose_score
+
+  # Check if we should restart raptoreumd according to the PoSe score.
+  if (( POSE_SCORE > 0 )); then
+    if (( POSE_SCORE > PREV_SCORE )); then
+      killall -9 raptoreumd
+      echo "$(date)  Score increased from ${PREV_SCORE} to ${POSE_SCORE} so sent kill signal..."
+      echo "1" >/tmp/was_stuck
+      # Do not check node height after killing raptoreumd.
+      exit
+    elif (( POSE_SCORE < PREV_SCORE )); then
+      echo "$(date)  Score decreased from ${PREV_SCORE} to ${POSE_SCORE} so wait..."
+      rm /tmp/was_stuck 2>/dev/null
+    fi
+    # POSE_SCORE == PREV_SCORE is gonna force check the node block height.
+  fi
+}
+
+function CheckBlockHeight () {
+  # Check local block height.
+  NETWORK_HEIGHT=$(curl -s "${URL[$URL_ID]}api/getblockcount")
+  if (( NETWORK_HEIGHT < 0 )); then
+    URL_ID=$(( (URL_ID + 1) % 2 ))
+    NETWORK_HEIGHT=$(curl -s "${URL[$URL_ID]}api/getblockcount")
+  fi
+  PREV_HEIGHT=$(ReadValue "/tmp/height")
+  LOCAL_HEIGHT=$(GetNumber $(ReadCli getblockcount))
+  echo ${LOCAL_HEIGHT} >/tmp/height
+  if (( POSE_SCORE == PREV_SCORE )); then
+    echo -n "$(date)  Node height (${LOCAL_HEIGHT}/${NETWORK_HEIGHT})."
+    # Block height did not change. Is it stuck?. Compare with netowrk block height. Allow some slippage.
+    if [[ $((NETWORK_HEIGHT - LOCAL_HEIGHT)) -gt 5 || $NETWORK_HEIGHT == -1 ]]; then
+      if (( LOCAL_HEIGHT > PREV_HEIGHT )); then
+        # Node is still syncing?
+        rm /tmp/was_stuck 2>/dev/null
+        echo " Increased from ${PREV_HEIGHT} -> ${LOCAL_HEIGHT} so wait..."
+      elif [[ $LOCAL_HEIGHT -gt 0 && $(ReadValue "/tmp/was_stuck") -lt 0 ]]; then
+        # Node is behind the network height and it is first attempt at unstucking.
+        # If LOCAL_HEIGHT is >0 it means that we were able to read from the cli
+        # but the height did not change compared to previous check.
+        killall -9 raptoreumd
+        echo "1" >/tmp/was_stuck
+        echo " Height difference is more than 5 blocks behind the network so sent kill signal..."
+      else
+        # Node is most probably very stuck and if trying to sync wrong chain branch.
+        # This meand simple raptoreumd kill will not help and we need to
+        # force unstuck by bootstrapping / resyncing the chain again.
+        echo " Node seems to be hardstuck and is trying to sync forked chain so force unstuck..."
+        return 1
+      fi
+    else
+      rm /tmp/was_stuck 2>/dev/null
+      echo " Daemon seems ok..."
+    fi
+  fi
+  return 0
+}
+
+function BootstrapChain () {
+  echo "$(date)  Re-Bootstrap the node chain."
+  echo "0" >/tmp/height
+  echo "0" >/tmp/prev_stuck
+  
+  BOOTSTRAP_TAR='https://www.dropbox.com/s/y885aysstdmro4n/rtm-bootstrap.tar.gz'
+  CONFIG_DIR='~/.raptoreumcore/'
+  
+  echo "$(date)  Download and prepare rtm-bootstrap."
+  rm -rf /tmp/bootstrap 2>/dev/null
+  mkdir /tmp/bootstrap 2>/dev/null
+  curl -L "$BOOTSTRAP_TAR" | tar xz -C /tmp/bootstrap
+  
+  echo "$(date)  Kill raptoreumd."
+  killall -9 raptoreumd 2>/dev/null
+
+  echo "$(date)  Clean ${CONFIG_DIR}."
+  rm -rf ${CONFIG_DIR}/{blocks,chainstate,evodb,llmq}
+
+  # Try to kill raptoreumd again in case it went back up.
+  killall -9 raptoreumd 2>/dev/null
+  echo "$(date)  Insert Bootstrap data."
+  mv tmp/bootstrap/{blocks,chainstate,evodb,llmq} ${CONFIG_DIR}/
+  
+  rm -rf /tmp/bootstrap 2>/dev/null
+}
+
+# This should force unstuck the local node.
+function ReconsiderBlock () {
+  if [[ $LOCAL_HEIGHT -gt 0 && $LOCAL_HEIGHT -gt $(ReadValue "/tmp/prev_stuck") ]]; then
+    # Node is still responsive but is stuck on the wrong branch/fork.
+    RECONSIDER=$(( LOCAL_HEIGHT - 5 ))
+    HASH=$(ReadCli getclockhash ${RECONSIDER})
+    if [[ ${HASH} != "-1" ]]; then
+      echo "$(date)  Reconsider chain from 5 blocks before current one ${RECONSIDER}"
+      if [[ $(ReadCli reconsiderblock "${HASH}") != "-1" ]]; then
+        echo ${RECONSIDER} >/tmp/height
+        echo ${LOCAL_HEIGHT} >/tmp/prev_stuck
+        return 0
+      fi
+    fi
+  fi
+  return 1
+}
+
+# Check pose score acording to the explorer data.
+CheckPoSe
+# PoSe seems fine, did not change or was not able to get the score.
+CheckBlockHeight || ReconsiderBlock || BootstrapChain

--- a/install.sh
+++ b/install.sh
@@ -311,7 +311,7 @@ function cron_job() {
     if whiptail --yesno "Would you like Cron to check on daemon's health every 15 minutes?" 8 63; then
       PROTX_HASH=$(whiptail --inputbox "Please enter your protx hash for this SmartNode" 8 51 3>&1 1>&2 2>&3)
       cat <(curl -s https://raw.githubusercontent.com/dk808/Raptoreum_Smartnode/main/check.sh) >$HOME/check.sh 
-      sed -i "s/#NODE_PROTX=/NODE_PROTX=\"${NODE_PROTX}\"/g" $HOME/check.sh
+      sed -i "s/#NODE_PROTX=/NODE_PROTX=\"${PROTX_HASH}\"/g" $HOME/check.sh
       sudo chmod 775 $HOME/check.sh
       crontab -l | grep -v "SHELL=/bin/bash" | crontab -
       crontab -l | grep -v "RAPTOREUM_CLI=$(which $COIN_CLI)" | crontab -

--- a/install.sh
+++ b/install.sh
@@ -40,92 +40,93 @@ echo -e
 echo -e "${CYAN}Node setup starting, press [CTRL-C] to cancel.${NC}"
 sleep 5
 if [ "$USERNAME" = "root" ]; then
-    echo -e "${CYAN}You are currently logged in as ${NC}root${CYAN}, please switch to a sudo user.${NC}"
-    exit
+  echo -e "${CYAN}You are currently logged in as ${NC}root${CYAN}, please switch to a sudo user.${NC}"
+  exit
 fi
 
 #functions
 function wipe_clean() {
-    echo -e "${YELLOW}Removing any instances of RTM...${NC}"
-    sudo systemctl stop $COIN_NAME > /dev/null 2>&1 && sleep 2
-    sudo $COIN_CLI stop > /dev/null 2>&1 && sleep 2
-    sudo killall $COIN_DAEMON > /dev/null 2>&1
-    sudo rm /usr/local/bin/$COIN_NAME* > /dev/null 2>&1 && sleep 1
-    sudo rm /usr/bin/$COIN_NAME* > /dev/null 2>&1 && sleep 1
-    rm -rf $HOME/$CONFIG_DIR > /dev/null 2>&1 && sleep 1
-    rm update.sh check.sh > /dev/null 2>&1 && sleep 1
-    rm -rf sentinel
+  echo -e "${YELLOW}Removing any instances of RTM...${NC}"
+  sudo systemctl stop $COIN_NAME > /dev/null 2>&1
+  sudo $COIN_CLI stop > /dev/null 2>&1
+  sudo killall $COIN_DAEMON > /dev/null 2>&1
+  sudo rm /usr/local/bin/$COIN_NAME* > /dev/null 2>&1
+  sudo rm /usr/bin/$COIN_NAME* > /dev/null 2>&1
+  rm -rf $HOME/$CONFIG_DIR > /dev/null 2>&1
+  rm update.sh check.sh > /dev/null 2>&1
+  rm -rf sentinel
 }
 
 function ssh_port() {
-    echo -e "${YELLOW}Detecting SSH port being used...${NC}" && sleep 1
-    SSHPORT=$(grep -w Port /etc/ssh/sshd_config | sed -e 's/.*Port //')
-    if ! whiptail --yesno "Detected you are using $SSHPORT for SSH is this correct?" 8 56; then
-        SSHPORT=$(whiptail --inputbox "Please enter port you are using for SSH" 8 43 3>&1 1>&2 2>&3)
-        echo -e "${YELLOW}Using SSH port:${SEA} $SSHPORT${NC}" && sleep 1
-    else
-        echo -e "${YELLOW}Using SSH port:${SEA} $SSHPORT${NC}" && sleep 1
-    fi
+  echo -e "${YELLOW}Detecting SSH port being used...${NC}" && sleep 1
+  SSHPORT=$(grep -w Port /etc/ssh/sshd_config | sed -e 's/.*Port //')
+  if ! whiptail --yesno "Detected you are using $SSHPORT for SSH is this correct?" 8 56; then
+    SSHPORT=$(whiptail --inputbox "Please enter port you are using for SSH" 8 43 3>&1 1>&2 2>&3)
+    echo -e "${YELLOW}Using SSH port:${SEA} $SSHPORT${NC}" && sleep 1
+  else
+    echo -e "${YELLOW}Using SSH port:${SEA} $SSHPORT${NC}" && sleep 1
+  fi
 }
 
 function ip_confirm() {
-    echo -e "${YELLOW}Detecting IP address being used...${NC}" && sleep 1
-    WANIP=$(wget http://ipecho.net/plain -O - -q)
-    if ! whiptail --yesno "Detected IP address is $WANIP is this correct?" 8 60; then
-        WANIP=$(whiptail --inputbox "        Enter IP address" 8 36 3>&1 1>&2 2>&3)
-    fi
+  echo -e "${YELLOW}Detecting IP address being used...${NC}" && sleep 1
+  WANIP=$(wget http://ipecho.net/plain -O - -q)
+  if ! whiptail --yesno "Detected IP address is $WANIP is this correct?" 8 60; then
+      WANIP=$(whiptail --inputbox "        Enter IP address" 8 36 3>&1 1>&2 2>&3)
+  fi
 }
 
 function create_swap() {
-    echo -e "${YELLOW}Creating swap if none detected...${NC}" && sleep 1
-    if ! grep -q "swapfile" /etc/fstab; then
-        if whiptail --yesno "No swapfile detected would you like to create one?" 8 54; then
-          sudo fallocate -l 4G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-          echo -e "${YELLOW}Created ${SEA}4G${YELLOW} swapfile${NC}"
-        fi
+  echo -e "${YELLOW}Creating swap if none detected...${NC}" && sleep 1
+  if ! grep -q "swapfile" /etc/fstab; then
+    if whiptail --yesno "No swapfile detected would you like to create one?" 8 54; then
+      sudo fallocate -l 4G /swapfile
+      sudo chmod 600 /swapfile
+      sudo mkswap /swapfile
+      sudo swapon /swapfile
+      echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+      echo -e "${YELLOW}Created ${SEA}4G${YELLOW} swapfile${NC}"
     fi
-    sleep 2
+  fi
+  sleep 1
 }
 
 function install_packages() { 
-    echo -e "${YELLOW}Installing Packages...${NC}"
-    sudo apt-get update -y
-    sudo apt-get upgrade -y
-    sudo apt-get install nano htop pwgen figlet unzip jq -y
-    echo -e "${YELLOW}Packages complete...${NC}"
+  echo -e "${YELLOW}Installing Packages...${NC}"
+  sudo apt-get update -y
+  sudo apt-get upgrade -y
+  sudo apt-get install nano htop pwgen figlet unzip jq -y
+  echo -e "${YELLOW}Packages complete...${NC}"
 }
 
 function spinning_timer() {
-    animation=( ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏ )
-    end=$((SECONDS+NUM))
-    while [ $SECONDS -lt $end ];
-    do
-        for i in "${animation[@]}";
-        do
-            echo -ne "${RED}\r$i ${CYAN}${MSG1}${NC}"
-            sleep 0.1
-        done
+  animation=( ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏ )
+  end=$((SECONDS+NUM))
+  while [ $SECONDS -lt $end ]; do
+    for i in "${animation[@]}"; do
+      echo -ne "${RED}\r$i ${CYAN}${MSG1}${NC}"
+      sleep 0.1
     done
-    echo -e "${MSG2}"
+  done
+  echo -e "${MSG2}"
 }
 
 function create_conf() {
-    if [ -f $HOME/$CONFIG_DIR/$CONFIG_FILE ]; then
-        echo -e "${CYAN}Existing conf file found backing up to $COIN_NAME.old ...${NC}"
-        mv $HOME/$CONFIG_DIR/$CONFIG_FILE $HOME/$CONFIG_DIR/$COIN_NAME.old;
-    fi
-    RPCUSER=$(pwgen -1 8 -n)
-    PASSWORD=$(pwgen -1 20 -n)
+  if [ -f $HOME/$CONFIG_DIR/$CONFIG_FILE ]; then
+    echo -e "${CYAN}Existing conf file found backing up to $COIN_NAME.old ...${NC}"
+    mv $HOME/$CONFIG_DIR/$CONFIG_FILE $HOME/$CONFIG_DIR/$COIN_NAME.old;
+  fi
+  RPCUSER=$(pwgen -1 8 -n)
+  PASSWORD=$(pwgen -1 20 -n)
+  smartnodeblsprivkey=$(whiptail --inputbox "Enter your SmartNode BLS Privkey" 8 75 3>&1 1>&2 2>&3)
+  while [[ -z $smartnodeblsprivkey ]]; do
     smartnodeblsprivkey=$(whiptail --inputbox "Enter your SmartNode BLS Privkey" 8 75 3>&1 1>&2 2>&3)
-    echo -e "${YELLOW}Creating Conf File...${NC}"
-    sleep 1
-    mkdir $HOME/$CONFIG_DIR > /dev/null 2>&1
-    touch $HOME/$CONFIG_DIR/$CONFIG_FILE
-    cat << EOF > $HOME/$CONFIG_DIR/$CONFIG_FILE
+  done
+  echo -e "${YELLOW}Creating Conf File...${NC}"
+  sleep 1
+  mkdir $HOME/$CONFIG_DIR > /dev/null 2>&1
+  touch $HOME/$CONFIG_DIR/$CONFIG_FILE
+  cat << EOF > $HOME/$CONFIG_DIR/$CONFIG_FILE
 rpcuser=$RPCUSER
 rpcpassword=$PASSWORD
 rpcallowip=127.0.0.1
@@ -143,21 +144,27 @@ EOF
 }
 
 function install_bins() {
-    echo -e "${YELLOW}Installing latest binaries...${NC}"
-    WALLET_TAR=$(curl -s https://api.github.com/repos/Raptor3um/raptoreum/releases/latest | jq -r '.assets[] | select(.name|test("ubuntu18.")) | .browser_download_url')
-    mkdir temp
-    curl -L $WALLET_TAR | tar xz -C ./temp; sudo mv ./temp/$COIN_DAEMON ./temp/$COIN_CLI ./temp/$COIN_TX $COIN_PATH
-    sudo chmod 755 ${COIN_PATH}/${COIN_NAME}*
-    rm -rf temp
+  echo -e "${YELLOW}Installing latest binaries...${NC}"
+  WALLET_TAR=$(curl -s https://api.github.com/repos/Raptor3um/raptoreum/releases/latest | jq -r '.assets[] | select(.name|test("ubuntu18.")) | .browser_download_url')
+  mkdir temp
+  curl -L $WALLET_TAR | tar xz -C ./temp; sudo mv ./temp/$COIN_DAEMON ./temp/$COIN_CLI ./temp/$COIN_TX $COIN_PATH
+  sudo chmod 755 ${COIN_PATH}/${COIN_NAME}*
+  rm -rf temp
 }
 
+BOOTSTRAP_ANS=""
+# If $1 is provided, just ask about bootstrap.
 function bootstrap() {
+  if [[ ! -z $1 ]]; then
     if whiptail --yesno "Would you like to bootstrap the chain?" 8 42; then
-        echo -e "${YELLOW}Downloading wallet bootstrap please be patient...${NC}"
-        curl -L $BOOTSTRAP_TAR | tar xz -C $HOME/$CONFIG_DIR
-    else
-        echo -e "${YELLOW}Skipping bootstrap...${NC}"
+      BOOTSTRAP_ANS=1
     fi
+  elif [[ ! -z $BOOTSTRAP_ANS ]]; then
+    echo -e "${YELLOW}Downloading wallet bootstrap please be patient...${NC}"
+    curl -L $BOOTSTRAP_TAR | tar xz -C $HOME/$CONFIG_DIR
+  else
+    echo -e "${YELLOW}Skipping bootstrap...${NC}"
+  fi
 }
 
 function update_script() {
@@ -184,34 +191,34 @@ EOF
 }
 
 function install_sentinel() {
-    echo -e "${YELLOW}Installing sentinel...${NC}"
-    git clone https://github.com/dashpay/sentinel.git && cd sentinel
-    virtualenv venv
-    venv/bin/pip install -r requirements.txt
-    #sentinel conf
-    SENTINEL_CONF=$(cat <<EOF
+  echo -e "${YELLOW}Installing sentinel...${NC}"
+  git clone https://github.com/dashpay/sentinel.git && cd sentinel
+  virtualenv venv
+  venv/bin/pip install -r requirements.txt
+  #sentinel conf
+  SENTINEL_CONF=$(cat <<EOF
 raptoreum_conf=/home/$USERNAME/$CONFIG_DIR/$CONFIG_FILE
 db_name=/home/$USERNAME/sentinel/database/sentinel.db
 db_driver=sqlite
 network=mainnet
 EOF
 )
-    echo -e "${YELLOW}Configuring sentinel and cron job...${NC}"
-    echo "$SENTINEL_CONF" > ~/sentinel/sentinel.conf
-    cd
-    crontab -l | grep -v "~/sentinel && ./venv/bin/python bin/sentinel.py" | crontab -
-    sleep 1
-    crontab -l > tempcron
-    echo "* * * * * cd ~/sentinel && ./venv/bin/python bin/sentinel.py > /dev/null 2>&1" >> tempcron
-    crontab tempcron
-    rm tempcron
+  echo -e "${YELLOW}Configuring sentinel and cron job...${NC}"
+  echo "$SENTINEL_CONF" > ~/sentinel/sentinel.conf
+  cd
+  crontab -l | grep -v "~/sentinel && ./venv/bin/python bin/sentinel.py" | crontab -
+  sleep 1
+  crontab -l > tempcron
+  echo "* * * * * cd ~/sentinel && ./venv/bin/python bin/sentinel.py > /dev/null 2>&1" >> tempcron
+  crontab tempcron
+  rm tempcron
 }
 
 function create_service() {
-    echo -e "${YELLOW}Creating RTM service...${NC}"
-    sudo touch /etc/systemd/system/$COIN_NAME.service
-    sudo chown $USERNAME:$USERNAME /etc/systemd/system/$COIN_NAME.service
-    cat << EOF > /etc/systemd/system/$COIN_NAME.service
+  echo -e "${YELLOW}Creating RTM service...${NC}"
+  sudo touch /etc/systemd/system/$COIN_NAME.service
+  sudo chown $USERNAME:$USERNAME /etc/systemd/system/$COIN_NAME.service
+  cat << EOF > /etc/systemd/system/$COIN_NAME.service
 [Unit]
 Description=$COIN_NAME service
 After=network.target
@@ -232,26 +239,31 @@ StartLimitBurst=5
 [Install]
 WantedBy=multi-user.target
 EOF
-    sudo chown root:root /etc/systemd/system/$COIN_NAME.service
-    sudo systemctl daemon-reload
-    sleep 4
-    sudo systemctl enable $COIN_NAME > /dev/null 2>&1
+  sudo chown root:root /etc/systemd/system/$COIN_NAME.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable $COIN_NAME > /dev/null 2>&1
 }
 
+SECURITY_ANS=""
+# If $1 is provided, just ask about bootstrap
 function basic_security() {
+  if [[ ! -z $1 ]]; then
     if whiptail --yesno "Would you like to setup basic firewall and fail2ban?" 8 56; then
-        echo -e "${YELLOW}Configuring firewall and enabling fail2ban...${NC}"
-        sudo apt-get install ufw fail2ban -y
-        sudo ufw allow $SSHPORT/tcp
-        sudo ufw allow $PORT/tcp
-        sudo ufw logging on
-        sudo ufw default deny incoming
-        sudo ufw default allow outgoing
-        sudo ufw limit OpenSSH
-        echo "y" | sudo ufw enable > /dev/null 2>&1
-        sudo touch /etc/fail2ban/jail.local
-        sudo chown $USERNAME:$USERNAME /etc/fail2ban/jail.local
-        cat << EOF > /etc/fail2ban/jail.local
+      SECURITY_ANS=1
+    fi
+  elif [[ ! -z $SECURITY_ANS ]]; then
+    echo -e "${YELLOW}Configuring firewall and enabling fail2ban...${NC}"
+    sudo apt-get install ufw fail2ban -y
+    sudo ufw allow $SSHPORT/tcp
+    sudo ufw allow $PORT/tcp
+    sudo ufw logging on
+    sudo ufw default deny incoming
+    sudo ufw default allow outgoing
+    sudo ufw limit OpenSSH
+    echo "y" | sudo ufw enable > /dev/null 2>&1
+    sudo touch /etc/fail2ban/jail.local
+    sudo chown $USERNAME:$USERNAME /etc/fail2ban/jail.local
+    cat << EOF > /etc/fail2ban/jail.local
 [sshd]
 enabled = true
 port = $SSHPORT
@@ -259,43 +271,41 @@ filter = sshd
 logpath = /var/log/auth.log
 maxretry = 3
 EOF
-        sudo chown root:root /etc/fail2ban/jail.local
-        sudo systemctl restart fail2ban > /dev/null 2>&1
-        sudo systemctl enable fail2ban > /dev/null 2>&1
-    else
-        echo -e "${YELLOW}Skipping basic security...${NC}"
-    fi
+    sudo chown root:root /etc/fail2ban/jail.local
+    sudo systemctl restart fail2ban > /dev/null 2>&1
+    sudo systemctl enable fail2ban > /dev/null 2>&1
+  else
+    echo -e "${YELLOW}Skipping basic security...${NC}"
+  fi
 }
 
 function start_daemon() {
-    NUM='180'
-    MSG1='Starting daemon service & syncing chain please be patient this will take few min...'
-    MSG=''
-    if sudo systemctl start $COIN_NAME > /dev/null 2>&1; then
-        echo && spinning_timer
-        NUM='5'
-        MSG1='Getting blockchain info...'
-        MSG2=''
-        echo && spinning_timer
-        echo
-        $COIN_CLI getblockchaininfo
-    else
-        echo -e "${RED}Something is not right the daemon did not start. Will exit out so try and run the script again.${NC}"
-        exit
-    fi
+  NUM='180'
+  MSG1='Starting daemon service & syncing chain please be patient this will take few min...'
+  MSG=''
+  if sudo systemctl start $COIN_NAME > /dev/null 2>&1; then
+    echo && spinning_timer
+    NUM='5'
+    MSG1='Getting blockchain info...'
+    MSG2=''
+    echo && spinning_timer
+    echo
+    $COIN_CLI getblockchaininfo
+  else
+    echo -e "${RED}Something is not right the daemon did not start. Will exit out so try and run the script again.${NC}"
+    exit
+  fi
 }
 
 function log_rotate() {
-    echo -e "${YELLOW}Configuring logrotate function for debug log...${NC}"
-    sleep 1
-    if [ -f /etc/logrotate.d/rtmdebuglog ]; then
-        echo -e "${YELLOW}Existing log rotate conf found, backing up to ~/rtmdebuglogrotate.old ...${NC}"
-        sudo mv /etc/logrotate.d/rtmdebuglog ~/rtmdebuglogrotate.old
-        sleep 2
-    fi
-    sudo touch /etc/logrotate.d/rtmdebuglog
-    sudo chown $USERNAME:$USERNAME /etc/logrotate.d/rtmdebuglog
-    cat << EOF > /etc/logrotate.d/rtmdebuglog
+  echo -e "${YELLOW}Configuring logrotate function for debug log...${NC}"
+  if [ -f /etc/logrotate.d/rtmdebuglog ]; then
+    echo -e "${YELLOW}Existing log rotate conf found, backing up to ~/rtmdebuglogrotate.old ...${NC}"
+    sudo mv /etc/logrotate.d/rtmdebuglog ~/rtmdebuglogrotate.old
+  fi
+  sudo touch /etc/logrotate.d/rtmdebuglog
+  sudo chown $USERNAME:$USERNAME /etc/logrotate.d/rtmdebuglog
+  cat << EOF > /etc/logrotate.d/rtmdebuglog
 /home/$USERNAME/.raptoreumcore/debug.log {
   compress
   copytruncate
@@ -304,31 +314,38 @@ function log_rotate() {
   rotate 7
 }
 EOF
-    sudo chown root:root /etc/logrotate.d/rtmdebuglog
+  sudo chown root:root /etc/logrotate.d/rtmdebuglog
 }
 
+CRON_ANS=""
+PROTX_HASH=""
+# If $1 is provided, just ask about bootstrap.
 function cron_job() {
+  if [[ ! -z $1 ]]; then
     if whiptail --yesno "Would you like Cron to check on daemon's health every 15 minutes?" 8 63; then
+      CRON_ANS=1
       PROTX_HASH=$(whiptail --inputbox "Please enter your protx hash for this SmartNode" 8 51 3>&1 1>&2 2>&3)
-      cat <(curl -s https://raw.githubusercontent.com/dk808/Raptoreum_Smartnode/main/check.sh) >$HOME/check.sh 
-      sed -i "s/#NODE_PROTX=/NODE_PROTX=\"${PROTX_HASH}\"/g" $HOME/check.sh
-      sudo chmod 775 $HOME/check.sh
-      crontab -l | grep -v "SHELL=/bin/bash" | crontab -
-      crontab -l | grep -v "RAPTOREUM_CLI=$(which $COIN_CLI)" | crontab -
-      crontab -l | grep -v "HOME=$HOME" | crontab -
-      crontab -l | grep -v "$HOME/check.sh >> $HOME/check.log" | crontab -
-      crontab -l > tempcron
-      echo "SHELL=/bin/bash" >> tempcron
-      echo "RAPTOREUM_CLI=$(which $COIN_CLI)" >> tempcron
-      echo "HOME=$HOME" >> tempcron
-      echo "*/15 * * * * $HOME/check.sh >> $HOME/check.log" >> tempcron
-      crontab tempcron
-      rm tempcron
-      rm -f /tmp/height 2>/dev/null
-      rm -f /tmp/pose_score 2>/dev/null
-      rm -f /tmp/was_stuck 2>/dev/null
-      rm -f /tmp/prev_stuck 2>/dev/null
     fi
+  elif [[ ! -z $CRON_ANS ]]; then
+    cat <(curl -s https://raw.githubusercontent.com/dk808/Raptoreum_Smartnode/main/check.sh) >$HOME/check.sh
+    sed -i "s/#NODE_PROTX=/NODE_PROTX=\"${PROTX_HASH}\"/g" $HOME/check.sh
+    sudo chmod 775 $HOME/check.sh
+    crontab -l | grep -v "SHELL=/bin/bash" | crontab -
+    crontab -l | grep -v "RAPTOREUM_CLI=$(which $COIN_CLI)" | crontab -
+    crontab -l | grep -v "HOME=$HOME" | crontab -
+    crontab -l | grep -v "$HOME/check.sh >> $HOME/check.log" | crontab -
+    crontab -l > tempcron
+    echo "SHELL=/bin/bash" >> tempcron
+    echo "RAPTOREUM_CLI=$(which $COIN_CLI)" >> tempcron
+    echo "HOME=$HOME" >> tempcron
+    echo "*/15 * * * * $HOME/check.sh >> $HOME/check.log" >> tempcron
+    crontab tempcron
+    rm tempcron
+    rm -f /tmp/height 2>/dev/null
+    rm -f /tmp/pose_score 2>/dev/null
+    rm -f /tmp/was_stuck 2>/dev/null
+    rm -f /tmp/prev_stuck 2>/dev/null
+  fi
 }
 
 function create_motd() {
@@ -381,16 +398,22 @@ EOF
 #
 #end of functions
 
-#run functions
+# Clean the enviroment from possibly previous setup.
   wipe_clean
+
+# Ask about about things first for quick setup.
   ssh_port
   ip_confirm
   create_swap
-  install_packages
   create_conf
+  basic_security true
+  bootstrap true
+  cron_job true
+
+#Run functionis.
+  install_packages
   install_bins
   bootstrap
-  #install_sentinel
   create_service
   basic_security
   start_daemon

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,8 @@ X_POINT="${BLINKRED}\xE2\x9D\x97${NC}"
 echo -e "${YELLOW}==========================================================="
 echo -e 'RTM Smartnode Setup'
 echo -e "===========================================================${NC}"
-echo -e "${BLUE}Feb 2021, created and updated by dk808 from AltTank${NC}"
+echo -e "${BLUE}July 2021, created and updated by dk808 from AltTank${NC}"
+echo -e "${BLUE}With Smartnode healthcheck by Delgon${NC}"
 echo -e
 echo -e "${CYAN}Node setup starting, press [CTRL-C] to cancel.${NC}"
 sleep 5
@@ -309,17 +310,16 @@ EOF
 function cron_job() {
     if whiptail --yesno "Would you like Cron to check on daemon's health every 15 minutes?" 8 63; then
       PROTX_HASH=$(whiptail --inputbox "Please enter your protx hash for this SmartNode" 8 51 3>&1 1>&2 2>&3)
-      cat <(curl -s https://raw.githubusercontent.com/michal-zurkowski/Raptoreum_Smartnode/main/check.sh) >$HOME/check.sh 
+      cat <(curl -s https://raw.githubusercontent.com/dk808/Raptoreum_Smartnode/main/check.sh) >$HOME/check.sh 
+      sed -i "s/#NODE_PROTX=/NODE_PROTX=\"${NODE_PROTX}\"/g" $HOME/check.sh
       sudo chmod 775 $HOME/check.sh
       crontab -l | grep -v "SHELL=/bin/bash" | crontab -
       crontab -l | grep -v "RAPTOREUM_CLI=$(which $COIN_CLI)" | crontab -
-      crontab -l | grep -v "NODE_PROTX=$PROTX_HASH" | crontab -
       crontab -l | grep -v "HOME=$HOME" | crontab -
       crontab -l | grep -v "$HOME/check.sh >> $HOME/check.log" | crontab -
       crontab -l > tempcron
       echo "SHELL=/bin/bash" >> tempcron
       echo "RAPTOREUM_CLI=$(which $COIN_CLI)" >> tempcron
-      echo "NODE_PROTX=$PROTX_HASH" >> tempcron
       echo "HOME=$HOME" >> tempcron
       echo "*/15 * * * * $HOME/check.sh >> $HOME/check.log" >> tempcron
       crontab tempcron
@@ -328,11 +328,6 @@ function cron_job() {
       rm -f /tmp/pose_score 2>/dev/null
       rm -f /tmp/was_stuck 2>/dev/null
       rm -f /tmp/prev_stuck 2>/dev/null
-
-      # Add PROTX to .bashrc in case user wants to run it manually.
-      sed -i '/NODE_PROTX=/d' $HOME/.bashrc
-      echo "export NODE_PROTX=$PROTX_HASH" >> $HOME/.bashrc
-      source $HOME/.bashrc
     fi
 }
 
@@ -361,6 +356,7 @@ printf "\${STOP}"
 
 echo -e "\${YELLOW}================================================================================================"
 echo -e "\${CYAN}COURTESY OF DK808 FROM ALTTANK ARMY\${NC}"
+echo -e "\${CYAN}Smartnode healthcheck by Delgon\${NC}"
 echo
 echo -e "\${YELLOW}Commands to manage \$COIN_NAME service\${NC}"
 echo -e "  TO START- \${CYAN}sudo systemctl start \$COIN_NAME\${NC}"

--- a/install.sh
+++ b/install.sh
@@ -313,12 +313,14 @@ function cron_job() {
       sudo chmod 775 $HOME/check.sh
       crontab -l | grep -v "SHELL=/bin/bash" | crontab -
       crontab -l | grep -v "RAPTOREUM_CLI=$(which $COIN_CLI)" | crontab -
-      crontab -l | grep -v "NODE_PROTX=$(PROTX_HASH)" | crontab -
+      crontab -l | grep -v "NODE_PROTX=$PROTX_HASH" | crontab -
+      crontab -l | grep -v "HOME=$HOME" | crontab -
       crontab -l | grep -v "$HOME/check.sh >> $HOME/check.log" | crontab -
       crontab -l > tempcron
       echo "SHELL=/bin/bash" >> tempcron
       echo "RAPTOREUM_CLI=$(which $COIN_CLI)" >> tempcron
-      echo "NODE_PROTX=$(PROTX_HASH)" >> tempcron
+      echo "NODE_PROTX=$PROTX_HASH" >> tempcron
+      echo "HOME=$HOME" >> tempcron
       echo "*/15 * * * * $HOME/check.sh >> $HOME/check.log" >> tempcron
       crontab tempcron
       rm tempcron
@@ -327,8 +329,9 @@ function cron_job() {
       rm -f /tmp/was_stuck 2>/dev/null
       rm -f /tmp/prev_stuck 2>/dev/null
 
-      sed -i 'NODE_PROTX=/d' $HOME/.bashrc
-      echo "NODE_PROTX=$(PROTX_HASH)" >> $HOME/.bashrc
+      # Add PROTX to .bashrc in case user wants to run it manually.
+      sed -i '/NODE_PROTX=/d' $HOME/.bashrc
+      echo "export NODE_PROTX=$PROTX_HASH" >> $HOME/.bashrc
       source $HOME/.bashrc
     fi
 }


### PR DESCRIPTION
### install.sh
- Ask input questions like firewall, ssh port, IP, BLS, etc, as a first step and set up everything after that. Should make node creation easier and faster for users.
- Small cleanup.

### check.sh
- Create internal check.sh on in repo that is being pulled from install.sh.
- Completely new script to check the health of the Smartnode:
#### Check PoSe from the explorer.
1. Check PoSe with the explorer.
1.1. If the PoSe increased compared to our previous check - something is wrong -> kill and exit (no need to check local height as it is 100% incorrect if the PoSe increased)
1.2. PoSe decreased, which means the node is synced - looks ok -> do nothing

#### Check height from the explorer and local height
2. Check local node height (even if it was 2.2) so we can have info in the next check about node height from this time.
3. If PoSe score stayed the same or we did not get any info from the explorer. Node ProTX is not necessary if you look at the whole script, check some options, otherwise do nothing
4. If the node is 5 blocks behind network check those, otherwise do nothing:
4.1 Node height increased compared to the previous check, it is syncing for now -> do nothing
4.2 Node stayed the same -> we were able to read from raptoreum-cli BUT was not stuck before. Try restarting the raptoreumd but also set flag/file that the node was stuck.
4.3 If we were not able to read from raptoreum-cli (it got timed out by itself or did not respond for 5 minutes, implemented my own kill for it) and the node was not stuck before. Try restarting raptoreumd and set a stuck flag. It might have been just stuck.
4.4 Everything else meaning pretty much we were not able to read, did not increase or whatever AND the stuck flag is set. Return error.

#### Try to soft unstuck by reconsiderblock
5. If 4 returned error (4.4) try to do raptoreum-cli reconsiderblock HASH.
5.1 If raptoreum-cli is still responsive, pick the 10th block from the top (close to current but should be far enough so it is not in the forked state), take its hash, and do raptoreum-cli reconsiderblock HASH. Here now also set a flag on what place we were stuck. If we are stuck again in the same place again, we will skip this step.
5.2 raptoreum-cli is unresponsive or we were stuck in this place recently, return an error.

#### Bootstrap the chain again.
6. Only if 5 returned error (pretty much last resort if we are not able to unstick the node by restarts or soft re-sync).
6.1 Download bootstrap into tmp.
6.2 Stop raptoreumd.
6.3 Remove raptoreum chain etc that is in bootstrap.
6.4 Move from bootstrap from tmp to .raptoreumcore