### PR TITLE
Update bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,12 +2,10 @@
 
 DIR='/raptoreum/.raptoreumcore'
 BOOTSTRAP_TAR='https://bootstrap.raptoreum.com/bootstraps/bootstrap.tar.xz'
-POWCACHE='https://github.com/dk808/Raptoreum_SmartNode/releases/download/v1.0.0/powcache.dat'
 
 if [ ! -d $DIR ]; then
   mkdir -p $DIR
   curl -L $BOOTSTRAP_TAR | tar xJ -C $DIR
-  curl -L $POWCACHE > $DIR//powcache.dat
 else
   echo "Datadir has been detected so bootstrap will not be used..."
 fi


### PR DESCRIPTION
Bootstrap tar already has matching updated powcache.dat in it. It was suggested in discord chat that it might cause issues if your github powcache is further behind on chain than the bootstrap itself.  Not 100% sure on that so you may want to close this without changes, but it would also require changing install.sh and as an alternative there is a powcache hosted on rtm website at https://bootstrap.raptoreum.com/powcaches/powcache.dat that should always be the newest version.  Totally your call on how to proceed, if you just close this PR because you know it to be unnecessary - totally fine.  You probably know more about it than I do -  just wanted to share the info over here without tagging you in discord!